### PR TITLE
readme and X64 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ How to build it?
 ----------------
 
  1. Open [`vcproj\GUP.vcxproj`](https://github.com/gup4win/wingup/blob/master/vcproj/GUP.vcxproj)
- 2. Build Notepad++ [like a normal Visual Studio project](https://msdn.microsoft.com/en-us/library/7s88b19e.aspx). with VS2013 or newer
+ 2. Build Notepad++ [like a normal Visual Studio project](https://msdn.microsoft.com/en-us/library/7s88b19e.aspx) with VS2013 or newer
 
 
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,8 @@ to make sure it responds to your WinGup with the correct xml data.
 How to build it?
 ----------------
 
-Before building WinGup, you have to build curl lib.
-Launch your Visual Studio Command Prompt then go to wingup\curl\winbuild, then launch the makefile:
-
- *cd wingup\curl\winbuild*
- 
- *nmake /f Makefile.vc mode=dll*
- 
-Once curl lib is generated, you can use VS2005 to build your WinGup.
+ 1. Open [`vcproj\GUP.vcxproj`](https://github.com/gup4win/wingup/blob/master/vcproj/GUP.vcxproj)
+ 2. Build Notepad++ [like a normal Visual Studio project](https://msdn.microsoft.com/en-us/library/7s88b19e.aspx). with VS2013 or newer
 
 
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ How to build it?
 ----------------
 
  1. Open [`vcproj\GUP.vcxproj`](https://github.com/gup4win/wingup/blob/master/vcproj/GUP.vcxproj)
- 2. Build Notepad++ [like a normal Visual Studio project](https://msdn.microsoft.com/en-us/library/7s88b19e.aspx) with VS2013 or newer
+ 2. Build WinGup [like a normal Visual Studio project](https://msdn.microsoft.com/en-us/library/7s88b19e.aspx) with VS2013 or newer
 
 
 

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -224,7 +224,7 @@ static size_t setProgress(HWND, double t, double d, double, double)
 	SendMessage(hProgressBar, PBM_STEPIT, 0, 0);
 
 	char percentage[128];
-	sprintf(percentage, "Downloading %s: %d %%", dlFileName.c_str(), ratio);
+	sprintf(percentage, "Downloading %s: %Iu %%", dlFileName.c_str(), ratio);
 	::SetWindowTextA(hProgressDlg, percentage);
 	return 0;
 };
@@ -397,7 +397,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpszCmdLine, int)
 		abortOrNot = nativeLang.getMessageString("MSGID_ABORTORNOT");
 
 		std::string updateInfo;
-		char errorBuffer[CURL_ERROR_SIZE];
+		char errorBuffer[CURL_ERROR_SIZE] = { 0 };
 
 		// Get your software's current version.
 		// If you pass the version number as the argument
@@ -557,7 +557,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpszCmdLine, int)
 			curl_easy_cleanup(curl);
 		}
 
-		if (res != 0)
+		if (res != CURLE_OK)
 		{
 			if (!isSilentMode)
 				::MessageBoxA(NULL, errorBuffer, "curl error", MB_OK);


### PR DESCRIPTION
-  update build description to current usage
-  further compiler warnings from VS analysis run fixed:

wingup\src\winmain.cpp(227): warning C6328: Size mismatch: 'unsigned __int64' passed as _Param_(4) when 'int' is required in call to 'sprintf'.
wingup\src\winmain.cpp(465): warning C6054: String 'errorBuffer' might not be zero-terminated.
wingup\src\winmain.cpp(465): warning C6001: Using uninitialized memory 'errorBuffer'. 