### PR TITLE
prepare appveyor config for VS2013, VS2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ which downloads a update package then installs it. By using cURL library
 and TinyXml module, WinGup is capable to deal with http protocol and process XML data.
 
 
+
+Build Status
+------------
+
+AppVeyor `VS2013` and `VS2015`  [![Build status](https://ci.appveyor.com/api/projects/status/lvpvctpyfc6bfo9l?svg=true)](https://ci.appveyor.com/project/chcg/wingup)
+
+
+
 Why WinGup?
 -----------
 
@@ -46,7 +54,7 @@ to store your update package, that's it!
 How is WinGup easy to use?
 --------------------------
 
-All you have to do is point WinGup to your url update page (by modifying gup.xml), 
+All you have to do is point WinGup to your url update page (by modifying gup.xml),
 then work on your pointed url update page (see getDownLoadUrl.php comes with the release)
 to make sure it responds to your WinGup with the correct xml data.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+version: 4.0.{build}
+image: Visual Studio 2015
+
+
+clone_depth: 1
+
+
+environment:
+  matrix:
+  - PlatformToolset: v140
+  - PlatformToolset: v120
+
+platform:
+    - x64
+    - Win32
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="Win32" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd c:\projects\wingup\vcproj
+    - msbuild GUP.vcxproj /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%"
+
+after_build:
+    - cd c:\projects\wingup\
+    - ps: >-
+        $wingupFileName = "GUP.$env:PLATFORM.$env:CONFIGURATION.$env:PLATFORMTOOLSET.exe"
+
+        if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "bin64\GUP.exe" -FileName "$wingupFileName"
+        }
+
+        if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Debug") {
+            Push-AppveyorArtifact "vcproj\x64\Debug\GUP.exe" -FileName "$wingupFileName"
+        }
+
+        if ($env:PLATFORM -eq "Win32" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "bin\GUP.exe" -FileName "$wingupFileName"
+        }
+
+        if ($env:PLATFORM -eq "Win32" -and $env:CONFIGURATION -eq "Debug") {
+            Push-AppveyorArtifact "vcproj\Debug\GUP.exe" -FileName "$wingupFileName"
+        }
+

--- a/src/TinyXml/tinyxmlparser.cpp
+++ b/src/TinyXml/tinyxmlparser.cpp
@@ -784,7 +784,7 @@ const char* TiXmlElement::Parse( const char* p, TiXmlParsingData* data )
 			}
 
 			attrib->SetDocument( document );
-			const char* pErr = p;
+			pErr = p;
 			p = attrib->Parse( p, data );
 
 			if ( !p || !*p )


### PR DESCRIPTION
- added appveyor config for VS2013, VS2015, x64, win32, debug, release
- added appveyor badge to README.md -> @donho  need to be adapted to your own build
- corrected VS2015 build issue:
  c:\projects\wingup\src\tinyxml\tinyxmlparser.cpp(787): warning C4456: declaration of 'pErr' hides previous local declaration

Could be further extended to automatically or manually deploy the build result of tags to the github release, see https://www.appveyor.com/docs/deployment/github/
