### PR TITLE
Fixed issue #14

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -579,7 +579,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpszCmdLine, int)
 
 		if (res != CURLE_OK)
 		{
-			if (!isSilentMode)
+			if (!isSilentMode && doAbort == false)
 				::MessageBoxA(NULL, errorBuffer, "curl error", MB_OK);
 			if (doAbort)
 			{


### PR DESCRIPTION
If user cancels update downloading, then no need to show curl error message.