### PR TITLE
WinGUP Enhancement 2 (Revised of PR #24)

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -220,8 +220,8 @@ static size_t setProgress(HWND, double t, double d, double, double)
 	// Once downloading is finish (100%) close the progress bar dialog
 	// as there is no need to keep it opened because
 	// new dailog asking to close the app will appear (if specified classname in configuration)
-	static bool IsDialogClosed = false;
-	if (!IsDialogClosed)
+	static bool isDialogClosed = false;
+	if (!isDialogClosed)
 	{
 		while (stopDL)
 			::Sleep(1000);
@@ -243,7 +243,7 @@ static size_t setProgress(HWND, double t, double d, double, double)
 		if (ratio == 100)
 		{
 			SendMessage(hProgressDlg, WM_COMMAND, IDOK, 0);
-			IsDialogClosed = true;
+			isDialogClosed = true;
 		}
 	}
 	return 0;


### PR DESCRIPTION
### Enhancement:

1. Fixes small glitch of curl. In very beginning curl returns garbage value to its CURLOPT_PROGRESSFUNCTION method which turns as showing invalid download percentage (e.g. 9223372036854775808%).
Possible temporary fix for Notepad++ issues ([#4666](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/4666) and [#4069](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/4069)) . May be updating latest curl might fix it.

2. Once downloading is completed, close the progress dialog as there is no need to keep it opened because either new messagebox to close the app or installer will appear based on classname is specified or not in the configuration.

![image](https://user-images.githubusercontent.com/14791461/47171767-3f100580-d327-11e8-9d52-dcee04981374.png)

