### PR TITLE
Moved exception handling to catch errors in setting-files

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -606,21 +606,21 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpszCmdLine, int)
 		customParam = getParamVal('p', lpszCmdLine);
 	}
 
-	// Object (gupParams) is moved here because we need app icon form configuration file
-	GupParameters gupParams("gup.xml");
-	appIconFile = gupParams.getSoftwareIcon();
-
-	if (isHelp)
-	{
-		::MessageBoxA(NULL, MSGID_HELP, "GUP Command Argument Help", MB_OK);
-		return 0;
-	}
-
-	GupExtraOptions extraOptions("gupOptions.xml");
-	GupNativeLang nativeLang("nativeLang.xml");
-
-	hInst = hInstance;
 	try {
+		// Object (gupParams) is moved here because we need app icon form configuration file
+		GupParameters gupParams("gup.xml");
+		appIconFile = gupParams.getSoftwareIcon();
+
+		if (isHelp)
+		{
+			::MessageBoxA(NULL, MSGID_HELP, "GUP Command Argument Help", MB_OK);
+			return 0;
+		}
+
+		GupExtraOptions extraOptions("gupOptions.xml");
+		GupNativeLang nativeLang("nativeLang.xml");
+
+		hInst = hInstance;
 		if (launchSettingsDlg)
 		{
 			if (extraOptions.hasProxySettings())


### PR DESCRIPTION
If user either is missing setting-files (gup.xml+gupOptions.xml+nativeLang.xml) or the XML is malformed a exception is thrown but not caught, leading to missed popup and a 'garbage' value for exitcode.